### PR TITLE
Make container requests/resources editable and explicit

### DIFF
--- a/helm/k8s-node-termination-handler/templates/deamonset.yaml
+++ b/helm/k8s-node-termination-handler/templates/deamonset.yaml
@@ -63,10 +63,6 @@ spec:
             value: ""
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
-        resources:
-          limits:
-            cpu: 150m
-            memory: 30Mi
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/helm/k8s-node-termination-handler/values.yaml
+++ b/helm/k8s-node-termination-handler/values.yaml
@@ -15,10 +15,13 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-resources: {}
-  # limits:
-  #   cpu: 150m
-  #   memory: 30Mi
+resources:
+  limits:
+    cpu: 150m
+    memory: 30Mi
+  requests:
+    cpu: 150m
+    memory: 30Mi
 
 securityContext:
   capabilities:


### PR DESCRIPTION
When I set requests on the current chart, they get ignored by helm (possibly because of the duplicate `resources` yaml tag?)
By default k8s takes limits as requests.

This PR makes both default limits and requests explicit in `values.yaml`, and allows the chart user to override them in their values.